### PR TITLE
Add utils (and some formatting changes)

### DIFF
--- a/sage_src/horizontal_st.py
+++ b/sage_src/horizontal_st.py
@@ -1,9 +1,9 @@
-#fast computations of sorted, normalized aplist of an elliptic curve
-#compute 'difference' between distribution for finite C and the 'semicircle" where difference is measured by L2-norm
-#take log and deal with error interval
-#finally provide nice plotting interfaces for all this
+# fast computations of sorted, normalized aplist of an elliptic curve
+# compute 'difference' between distribution for finite C and the 'semicircle" where difference is measured by L2-norm
+# take log and deal with error interval
+# finally provide nice plotting interfaces for all this
 
-from math import log, sqrt, asin
+from math import log, sqrt
 import matplotlib.pyplot as plt
 import numpy as np
 import bisect
@@ -11,17 +11,8 @@ from sage.plot.line import line
 from sage.plot.point import point
 from sage.calculus.integration import numerical_integral as integral_numerical
 from sage.rings.fast_arith import prime_range
+from .utils import Xab
 
-def Xab(a,b):
-    """
-    return a function X(T)
-    where X(T) is the area under the arc of the semicircle from a to T
-    """
-    bb = (asin(b)/2.0 + b*sqrt(1.0-b**2.0)/2.0)
-    aa = (asin(a)/2.0 + a*sqrt(1.0-a**2.0)/2.0)
-    def X(T):
-        return (asin(T)/2.0 + T*sqrt(1.0-T**2.0)/2.0 - aa)/(bb - aa)
-    return X
 
 class SatoTate:
     """
@@ -62,6 +53,7 @@ class SatoTate:
     -histogram
         plot histogram of normalized_aplist(Cmax), divided in num_bins bins
     """
+
     def __init__(self, E):
         self._E = E
         self._normalized_aplist = []
@@ -82,16 +74,16 @@ class SatoTate:
         if len(self._normalized_aplist) >= pi:
             return self._normalized_aplist[0:pi]
         anlist = self.anlist(n)
-        v = [float(anlist[p])/float(2 * sqrt(p)) for p in primes]
+        v = [float(anlist[p]) / float(2 * sqrt(p)) for p in primes]
         self._normalized_aplist = v
         return v.copy()
-    
+
     def normalized_aplist(self, n):
         """
         normalize aplist from self.anlist
         """
         anlist = self.anlist(n)
-        v = [float(anlist[p])/float(2 * sqrt(p)) for p in prime_range(n)]
+        v = [float(anlist[p]) / float(2 * sqrt(p)) for p in prime_range(n)]
         return v
 
     def sorted_aplist(self, n):
@@ -101,109 +93,131 @@ class SatoTate:
         v = self.normalized_aplist_with_caching(n)
         v.sort()
         return v
-            
+
     def YCab(self, Cmax, a=-1, b=1):
         """
         return a function Y(T)
         where Y(T) is the area under the 'histogram' from a to T
         """
         v = self.sorted_aplist(Cmax)
-        
+
         denom = bisect.bisect_right(v, float(b)) - bisect.bisect_left(v, float(a))
         try:
-            normalize = float(1)/denom
+            normalize = float(1) / denom
         except:
+
             def Y(T):
                 return 1.0
+
             return Y
         start_pos = bisect.bisect_left(v, float(a))
-        
+
         def Y(T):
             # find position that T would go in if it were inserted
             # in the sorted list v.
             n = bisect.bisect_right(v, float(T)) - start_pos
             return n * normalize
+
         return Y
-    
+
     def Delta(self, C, a, b, max_points=300):
         """
         compute Delta_a^b(C)
         where max_points is the number of points used in numerical integration
         """
-        key = (C,a,b,max_points)
+        key = (C, a, b, max_points)
         try:
             return self._delta[key]
         except AttributeError:
             self._delta = {}
         except KeyError:
             pass
-        X = Xab(a,b)
-        Y = self.YCab(C,a,b)
+        X = Xab(a, b)
+        Y = self.YCab(C, a, b)
+
         def h(T):
-            return (X(T) - Y(T))**2.0
-        
-        val, err = integral_numerical(h, a, b, max_points=max_points, algorithm='qag', rule=1, eps_abs=1e-10, eps_rel=1e-10)
-        
+            return (X(T) - Y(T)) ** 2.0
+
+        val, err = integral_numerical(
+            h,
+            a,
+            b,
+            max_points=max_points,
+            algorithm="qag",
+            rule=1,
+            eps_abs=1e-10,
+            eps_rel=1e-10,
+        )
+
         self._delta[key] = (val, err)
         return val, err
-    
+
     def plot_Delta(self, Cmax, plot_points=400, max_points=100, a=-1, b=1):
         """
         plot Delta_a^b(x) from 0 to Cmax (use plot_points plot points)
         """
-        v = [(x,self.Delta(x, a, b, max_points=max_points)[0]) for x in range(0, Cmax, int(Cmax/plot_points))]
-        p = line(v,rgbcolor=(0,0,0), ymin=0, ymax=0.1)
-        p.axes_labels(['$C$', '$\\Delta$'])
+        v = [
+            (x, self.Delta(x, a, b, max_points=max_points)[0])
+            for x in range(0, Cmax, int(Cmax / plot_points))
+        ]
+        p = line(v, rgbcolor=(0, 0, 0), ymin=0, ymax=0.1)
+        p.axes_labels(["$C$", "$\\Delta$"])
         return p
-    
+
     def theta(self, C, a=-1, b=1, max_points=300):
         """
         compute theta from Delta
         """
         val, err = self.Delta(C, a, b, max_points=max_points)
-        return -log(val)/log(C), val, err
-    
+        return -log(val) / log(C), val, err
+
     def theta_error_bound(self, C, a=-1, b=1, max_points=300):
         """
         compute error bound from numerical integration
         """
         val, err = self.Delta(C, a, b, max_points=max_points)
-        return -log(val-abs(err))/log(C), -log(val+abs(err))/log(C)
-    
-    def theta_range(self, Cmax, plot_points=30, a=-1, b=1, max_points=300, verbose=False):
+        return -log(val - abs(err)) / log(C), -log(val + abs(err)) / log(C)
+
+    def theta_range(
+        self, Cmax, plot_points=30, a=-1, b=1, max_points=300, verbose=False
+    ):
         """
         compute list of (x, theta(x)) pairs where x <= Cmax
         use in total plot_points different equally distributed values for x
         where max_points is the number of points used in numerical integration
         """
-        a,b = (float(a), float(b))
-        
+        a, b = (float(a), float(b))
+
         def f(C):
             z = self.theta(C, a, b, max_points=max_points)
-            if verbose: print(C, z)
+            if verbose:
+                print(C, z)
             return z[0]
 
-        #calls theta (= log etc. angewandt auf Delta)
-        return [(x,f(x)) for x in range(100, Cmax, int(Cmax/plot_points))]
-    
-    def theta_error_bound_range(self, Cmax, plot_points=30, a=-1, b=1, max_points=300, verbose=False):
+        # calls theta (= log etc. angewandt auf Delta)
+        return [(x, f(x)) for x in range(100, Cmax, int(Cmax / plot_points))]
+
+    def theta_error_bound_range(
+        self, Cmax, plot_points=30, a=-1, b=1, max_points=300, verbose=False
+    ):
         """
         compute lists of (x, theta_max(x)) or (x, theta_min(x)) pairs where x <= Cmax
         use in total plot_points different equally distributed values for x
         where max_points is the number of points used in numerical integration
         and theta_max/theta_min are upper/lower error bounds for the result of the numerical integration
         """
-        a,b = (float(a), float(b))
-        vmin = []; vmax = []
-        for C in range(100, Cmax, int(Cmax/plot_points)):
-            zmin,zmax = self.theta_error_bound(C, a, b, max_points=max_points)
+        a, b = (float(a), float(b))
+        vmin = []
+        vmax = []
+        for C in range(100, Cmax, int(Cmax / plot_points)):
+            zmin, zmax = self.theta_error_bound(C, a, b, max_points=max_points)
             vmin.append((C, zmin))
             vmax.append((C, zmax))
-            if verbose: 
+            if verbose:
                 print(C, zmin, zmax)
         return vmin, vmax
-    
-    def plot_theta(self, Cmax, clr=(0,0,0), show_error_bound=True, *args, **kwds):
+
+    def plot_theta(self, Cmax, clr=(0, 0, 0), show_error_bound=True, *args, **kwds):
         """
         plot theta(x) for x from 0 to Cmax
         if show_error_bound is True the upper and lower error_bound is shown
@@ -212,37 +226,43 @@ class SatoTate:
         if show_error_bound:
             vmin, vmax = self.theta_error_bound_range(Cmax, *args, **kwds)
         v = self.theta_range(Cmax, *args, **kwds)
-        grey = (0.7,0.7,0.7)
-        theta_line = line(v,rgbcolor=clr, ymin=0,ymax=1.2, legend_label='$\\theta(C)$') 
-        theta_points = point(v,rgbcolor=clr)
+        grey = (0.7, 0.7, 0.7)
+        theta_line = line(
+            v, rgbcolor=clr, ymin=0, ymax=1.2, legend_label="$\\theta(C)$"
+        )
+        theta_points = point(v, rgbcolor=clr)
         if show_error_bound:
-            error_bound = line(vmin,rgbcolor=grey, legend_label='numerical integration error bound') + line(vmax,rgbcolor=grey)
-        reference_line = line([(0,1),(Cmax,1)], rgbcolor=(1,0,0), legend_label='$\\theta=1.0$')
-        
+            error_bound = line(
+                vmin, rgbcolor=grey, legend_label="numerical integration error bound"
+            ) + line(vmax, rgbcolor=grey)
+        reference_line = line(
+            [(0, 1), (Cmax, 1)], rgbcolor=(1, 0, 0), legend_label="$\\theta=1.0$"
+        )
+
         p = theta_line + theta_points + reference_line
         if show_error_bound:
             p = p + error_bound
 
-        p.axes_labels(['$C$ ', '$\\theta$'])
+        p.axes_labels(["$C$ ", "$\\theta$"])
         p.legend(True)
-        
+
         return p
-        
+
     def histogram(self, Cmax, num_bins):
-        '''
+        """
         plot histogram of normalized_aplist(Cmax), divided in num_bins bins
-        '''
+        """
         v = self.normalized_aplist(Cmax)
         print("num_bins:", num_bins)
         n, bins, patches = plt.hist(v, num_bins, density=True)
         angle = np.linspace(0, np.pi, 150)
         radius = 1
-        x = radius * np.cos(angle) 
-        y = radius * np.sin(angle) * 2 / np.pi #stretching so that area = 1
+        x = radius * np.cos(angle)
+        y = radius * np.sin(angle) * 2 / np.pi  # stretching so that area = 1
         plt.plot(x, y)
-        plt.xlabel('$a_p/\\sqrt{p}$')
-        plt.ylabel('Frequency')
-        plt.title('Sato-Tate-Distribution for E = {}'.format(self._E))
-        plt.xlim(-1,1)
+        plt.xlabel("$a_p/\\sqrt{p}$")
+        plt.ylabel("Frequency")
+        plt.title("Sato-Tate-Distribution for E = {}".format(self._E))
+        plt.xlim(-1, 1)
         plt.grid(True)
         plt.show()

--- a/sage_src/utils.py
+++ b/sage_src/utils.py
@@ -1,0 +1,22 @@
+"""utils.py
+
+Some functions common to all files in this directory.
+
+"""
+
+
+from math import sqrt, asin
+
+
+def Xab(a, b):
+    """
+    return a function X(T)
+    where X(T) is the area under the arc of the semicircle from a to T
+    """
+    bb = asin(b) / 2.0 + b * sqrt(1.0 - b ** 2.0) / 2.0
+    aa = asin(a) / 2.0 + a * sqrt(1.0 - a ** 2.0) / 2.0
+
+    def X(T):
+        return (asin(T) / 2.0 + T * sqrt(1.0 - T ** 2.0) / 2.0 - aa) / (bb - aa)
+
+    return X

--- a/sage_src/vertical_st.py
+++ b/sage_src/vertical_st.py
@@ -1,56 +1,58 @@
-#fast computations of sorted, normalized ap values for all elliptic curves over F_p for given p
-#compute 'difference' between distribution for finite p and the 'semicircle" where difference is measured by L2 or L1-norm
-#take log and deal with error interval
-#finally provide nice plotting interfaces for all this
+# fast computations of sorted, normalized ap values for all elliptic curves over F_p for given p
+# compute 'difference' between distribution for finite p and the 'semicircle" where difference is measured by L2 or L1-norm
+# take log and deal with error interval
+# finally provide nice plotting interfaces for all this
 #
-#Functions:
+# Functions:
 #
-#-fast_aplist(p)
+# -fast_aplist(p)
 #   compute a list of the a_p value of all elliptic curves over F_p
-#-sorted_aplist(p)
+# -sorted_aplist(p)
 #   sort ap_list(p)
-#-histogram(p)
+# -histogram(p)
 #   plot histogram of fast_aplist(p), divided in num_bins bins
-#-Xab
+# -Xab
 #   return a function X(T)
 #    where X(T) is the area under the arc of the semicircle from a to T
-#-Ypab
+# -Ypab
 #   return a function Y(T)
 #   where Y(T) is the area under the 'histogram' from a to T
-#-Delta
-#compute Delta_a^b(p)
+# -Delta
+# compute Delta_a^b(p)
 #   where max_points is the number of points used in numerical integration
 #   and norm is either 'l2' or 'l1'
-#-plot_Delta
+# -plot_Delta
 #   plot Delta_a^b(p) from 0 to pmax (use every stepsize-th prime)
-#-theta
+# -theta
 #   compute theta from Delta
-#-theta_error_bound
+# -theta_error_bound
 #   compute error bound from numerical integration
-#-theta_range
+# -theta_range
 #   compute list of (x, theta(x)) pairs where x is a prime <= p
 #   use every stepsize-th prime for x
 #   where max_points is the number of points used in numerical integration
 #   if step_size is not given the function estimates a proper size depending on p
-#-theta_error_bound_range
+# -theta_error_bound_range
 #   compute lists of (x, theta_max(x)) or (x, theta_min(x)) pairs where x is a prime <= p
 #   use every stepsize-th prime for x
 #   where max_points is the number of points used in numerical integration
 #   and theta_max/theta_min are upper/lower error bounds for the result of the numerical integration
 #   if step_size is not given the function estimates a proper size depending on p
-#-plot_theta
-#plot theta(x) for x prime from 0 to p
+# -plot_theta
+# plot theta(x) for x prime from 0 to p
 #   if show_error_bound is True the upper and lower error_bound is shown
 
 import matplotlib.pyplot as plt
 import numpy as np
-from math import log, sqrt, asin
+from math import log, sqrt
 import bisect
 from sage.plot.line import line
 from sage.plot.point import point
 from sage.calculus.integration import numerical_integral as integral_numerical
 from sage.libs.pari import pari
 from sage.rings.fast_arith import prime_range
+from .utils import Xab
+
 
 def fast_aplist(p):
     """
@@ -58,14 +60,17 @@ def fast_aplist(p):
     """
     ap_list = np.array([])
     for a in range(0, int(2 * sqrt(p))):
-        val = int(4*p - a**2)
-        hurwitz_number = int(pari(int(4*p - a**2)).qfbhclassno()) #need to change sign because of implementaion of hurwitz class number        
+        val = int(4 * p - a ** 2)
+        hurwitz_number = int(
+            pari(int(4 * p - a ** 2)).qfbhclassno()
+        )  # need to change sign because of implementaion of hurwitz class number
         ret_list = np.zeros(hurwitz_number)
-        ret_list += float(a/float(2 * sqrt(p)))
+        ret_list += float(a / float(2 * sqrt(p)))
         ap_list = np.append(ap_list, ret_list)
         if a != 0:
             ap_list = np.append(ap_list, -ret_list)
     return ap_list
+
 
 def sorted_aplist(p):
     """
@@ -75,34 +80,25 @@ def sorted_aplist(p):
     v.sort()
     return v
 
+
 def histogram(num_bins, p):
     """
     plot histogram of fast_aplist(p), divided in num_bins bins
     """
     v = fast_aplist(p)
     n, bins, patches = plt.hist(v, num_bins, density=True)
-    angle = np.linspace(0, np.pi, 150) 
+    angle = np.linspace(0, np.pi, 150)
     radius = 1
-    x = radius * np.cos(angle) 
-    y = radius * np.sin(angle) * 2 / np.pi #stretching so that area = 1
+    x = radius * np.cos(angle)
+    y = radius * np.sin(angle) * 2 / np.pi  # stretching so that area = 1
     plt.plot(x, y)
-    plt.xlabel('$a_p/2\\sqrt{p}$')
-    plt.ylabel('Frequency')
-    plt.title('Vertical Sato-Tate-Distribution for p = {}'.format(p))
-    plt.xlim(-1,1)
+    plt.xlabel("$a_p/2\\sqrt{p}$")
+    plt.ylabel("Frequency")
+    plt.title("Vertical Sato-Tate-Distribution for p = {}".format(p))
+    plt.xlim(-1, 1)
     plt.grid(True)
     plt.show()
 
-def Xab(a,b):
-    """
-    return a function X(T)
-    where X(T) is the area under the arc of the semicircle from a to T
-    """
-    bb = (asin(b)/2.0 + b*sqrt(1.0-b**2.0)/2.0)
-    aa = (asin(a)/2.0 + a*sqrt(1.0-a**2.0)/2.0)
-    def X(T):
-        return (asin(T)/2.0 + T*sqrt(1.0-T**2.0)/2.0 - aa)/(bb - aa)
-    return X
 
 def Ypab(p, a=-1, b=1):
     """
@@ -112,10 +108,12 @@ def Ypab(p, a=-1, b=1):
     v = sorted_aplist(p)
     denom = bisect.bisect_right(v, float(b)) - bisect.bisect_left(v, float(a))
     try:
-        normalize = float(1)/denom
+        normalize = float(1) / denom
     except:
+
         def Y(T):
             return 1.0
+
         return Y
     start_pos = bisect.bisect_left(v, float(a))
 
@@ -124,59 +122,79 @@ def Ypab(p, a=-1, b=1):
         # in the sorted list v.
         n = bisect.bisect_right(v, float(T)) - start_pos
         return n * normalize
+
     return Y
+
 
 global _delta
 
-def Delta(p, a, b, max_points=300, norm='l2'):
+
+def Delta(p, a, b, max_points=300, norm="l2"):
     """
     compute Delta_a^b(p)
     where max_points is the number of points used in numerical integration
     and norm is either 'l2' or 'l1'
     """
     global _delta
-    key = (p,a,b,max_points)
+    key = (p, a, b, max_points)
     try:
         return _delta[key]
     except NameError:
         _delta = {}
     except KeyError:
         pass
-    X = Xab(a,b)
-    Y = Ypab(p,a,b)
+    X = Xab(a, b)
+    Y = Ypab(p, a, b)
+
     def h(T):
-        if norm=='l2':
-            return (X(T) - Y(T))**2.0
-        if norm=='l1':
+        if norm == "l2":
+            return (X(T) - Y(T)) ** 2.0
+        if norm == "l1":
             return abs(X(T) - Y(T))
-    
-    val, err = integral_numerical(h, a, b, max_points=max_points, algorithm='qag', rule=1, eps_abs=1e-10, eps_rel=1e-10)
-    
+
+    val, err = integral_numerical(
+        h,
+        a,
+        b,
+        max_points=max_points,
+        algorithm="qag",
+        rule=1,
+        eps_abs=1e-10,
+        eps_rel=1e-10,
+    )
+
     _delta[key] = (val, err)
     return val, err
+
 
 def plot_Delta(pmax, step_size=10, max_points=100, a=-1, b=1):
     """
     plot Delta_a^b(p) from 0 to pmax (use every stepsize-th prime)
     """
-    v = [(p,Delta(p, a, b, max_points=max_points)[0]) for p in prime_range(pmax)[4:][::step_size]] #skip 2,3,5,7 and then take only every step_size-th prime
-    p = line(v,rgbcolor=(0,0,0), ymin=0, ymax=0.1)
-    p.axes_labels(['$p$', '$\\Delta$'])
+    v = [
+        (p, Delta(p, a, b, max_points=max_points)[0])
+        for p in prime_range(pmax)[4:][::step_size]
+    ]  # skip 2,3,5,7 and then take only every step_size-th prime
+    p = line(v, rgbcolor=(0, 0, 0), ymin=0, ymax=0.1)
+    p.axes_labels(["$p$", "$\\Delta$"])
     return p
+
 
 def theta(p, a=-1, b=1, max_points=300):
     """
     compute theta from Delta
     """
     val, err = Delta(p, a, b, max_points=max_points)
-    return -log(val)/log(p), val, err
+    return -log(val) / log(p), val, err
+
 
 def theta_error_bound(p, a=-1, b=1, max_points=300):
     """
     compute error bound from numerical integration
     """
     val, err = Delta(p, a, b, max_points=max_points)
-    return -log(val-abs(err))/log(p), -log(val+abs(err))/log(p)
+    return -log(val - abs(err)) / log(p), -log(val + abs(err)) / log(p)
+
 
 def theta_range(p, step_size=None, a=-1, b=1, max_points=300):
     """
@@ -185,16 +203,19 @@ def theta_range(p, step_size=None, a=-1, b=1, max_points=300):
     where max_points is the number of points used in numerical integration
     if step_size is not given the function estimates a proper size depending on p
     """
-    a,b = (float(a), float(b))
+    a, b = (float(a), float(b))
     if not step_size:
-        step_size = max(1, int(p/(20 * log(p)))) # grows with pi(p)
+        step_size = max(1, int(p / (20 * log(p))))  # grows with pi(p)
 
     def f(p):
         z = theta(p, a, b, max_points=max_points)
         return z[0]
 
-    #calls theta (= log etc. angewandt auf Delta)
-    return [(x,f(x)) for x in prime_range(p)[25:][::step_size]]#skip the first 25 primes and then take only every step_size-th prime
+    # calls theta (= log etc. angewandt auf Delta)
+    return [
+        (x, f(x)) for x in prime_range(p)[25:][::step_size]
+    ]  # skip the first 25 primes and then take only every step_size-th prime
+
 
 def theta_error_bound_range(p, step_size=None, a=-1, b=1, max_points=300):
     """
@@ -204,17 +225,21 @@ def theta_error_bound_range(p, step_size=None, a=-1, b=1, max_points=300):
     and theta_max/theta_min are upper/lower error bounds for the result of the numerical integration
     if step_size is not given the function estimates a proper size depending on p
     """
-    a,b = (float(a), float(b))
+    a, b = (float(a), float(b))
     if not step_size:
-        step_size = max(1, int(p/(20 * log(p)))) # grows with pi(p)
-    vmin = []; vmax = []
-    for C in prime_range(p)[25:][::step_size]:#skip the first 25 primes and then take only every step_size-th prime
-        zmin,zmax = theta_error_bound(C, a, b, max_points=max_points)
+        step_size = max(1, int(p / (20 * log(p))))  # grows with pi(p)
+    vmin = []
+    vmax = []
+    for C in prime_range(p)[25:][
+        ::step_size
+    ]:  # skip the first 25 primes and then take only every step_size-th prime
+        zmin, zmax = theta_error_bound(C, a, b, max_points=max_points)
         vmin.append((C, zmin))
         vmax.append((C, zmax))
     return vmin, vmax
 
-def plot_theta(p, clr=(0,0,0), show_error_bound=True, *args, **kwds):
+
+def plot_theta(p, clr=(0, 0, 0), show_error_bound=True, *args, **kwds):
     """
     plot theta(x) for x prime from 0 to p
     if show_error_bound is True the upper and lower error_bound is shown
@@ -222,18 +247,22 @@ def plot_theta(p, clr=(0,0,0), show_error_bound=True, *args, **kwds):
     if show_error_bound:
         vmin, vmax = theta_error_bound_range(p, *args, **kwds)
     v = theta_range(p, *args, **kwds)
-    grey = (0.7,0.7,0.7)
-    theta_line = line(v,rgbcolor=clr,ymin=0,ymax=1.5, legend_label='$\\theta(p)$')
-    theta_points = point(v,rgbcolor=clr)
+    grey = (0.7, 0.7, 0.7)
+    theta_line = line(v, rgbcolor=clr, ymin=0, ymax=1.5, legend_label="$\\theta(p)$")
+    theta_points = point(v, rgbcolor=clr)
     if show_error_bound:
-        error_bound = line(vmin,rgbcolor=grey, legend_label='numerical integration error bound') + line(vmax,rgbcolor=grey)
-    reference_line = line([(0,1),(p,1)], rgbcolor=(1,0,0), legend_label='$\\theta=1.0$')
-    
+        error_bound = line(
+            vmin, rgbcolor=grey, legend_label="numerical integration error bound"
+        ) + line(vmax, rgbcolor=grey)
+    reference_line = line(
+        [(0, 1), (p, 1)], rgbcolor=(1, 0, 0), legend_label="$\\theta=1.0$"
+    )
+
     p = theta_line + theta_points + reference_line
     if show_error_bound:
         p = p + error_bound
 
-    p.axes_labels(['$p$', '$\\theta$'])
+    p.axes_labels(["$p$", "$\\theta$"])
     p.legend(True)
 
     return p


### PR DESCRIPTION
This is how you'd have a utils file; in the same directory, and the other modules would import functions from it with

```
from .utils import Xab
```

This PR is just to show you how to do this; it's up to you if you want to merge it or not.

The other changes are formatting changes to make it PEP8 compliant. These were done automatically upon save, which is how I've got my VSCode set up:

```
"[python]": {
    "editor.rulers": [
      72,
      79
    ],
    "editor.tabSize": 4,
    "editor.detectIndentation": false,
    "editor.formatOnSave": true
```

Apologies if this makes the PR look messy. I find this feature useful to get code looking nice and readable, though be warned that if you're working on other open-source projects, people tend to find lots of "whitespace-only" changes distracting, since it's hard to tell what your real substantial changes are. (So e.g. when I'm working on the LMFDB, I have `"editor.formatOnSave": false`.)
